### PR TITLE
Create API helpers

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,7 +1,20 @@
 import authorization.AccessTokenExpirationWatchdog
 import authorization.AccessTokenManager
+import data.net.ServiceBuilder
+import data.net.api.IdentityService
+import data.net.helper.IdentityHelper
+import file.FileTokenManager
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
-    AccessTokenManager.codeFlowAuthorization()
+    AccessTokenExpirationWatchdog.checkAccessTokenExpiration(1000)
+
+    val accessToken = FileTokenManager.getAccessTokenFromFile().accessToken
+    val authString = "Bearer $accessToken"
+    val response = IdentityHelper.getIdentity(authString)
+    if (response.isSuccessful) {
+        println("success")
+        println("body:\n${response.body()}")
+    } else
+        println("failed")
 }

--- a/src/main/kotlin/data/net/ServiceBuilder.kt
+++ b/src/main/kotlin/data/net/ServiceBuilder.kt
@@ -18,7 +18,8 @@ object ServiceBuilder {
         return Retrofit.Builder()
             .baseUrl(baseUrl)
             // Required to enable Kotlin serialization with Retrofit
-            .addConverterFactory(Json.asConverterFactory(contentType))
+            // Note that I'm using a custom JSON configuration that is more lenient
+            .addConverterFactory(jsonParser.asConverterFactory(contentType))
             .build()
     }
 

--- a/src/main/kotlin/data/net/ServiceBuilder.kt
+++ b/src/main/kotlin/data/net/ServiceBuilder.kt
@@ -5,7 +5,6 @@ import constant.RegisteredAppInformation
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
-import retrofit2.create
 
 object ServiceBuilder {
 

--- a/src/main/kotlin/data/net/api/IdentityService.kt
+++ b/src/main/kotlin/data/net/api/IdentityService.kt
@@ -2,12 +2,17 @@ package data.net.api
 
 import data.net.model.Identity
 import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.Headers
 
 
 interface IdentityService {
 
+    @Headers(
+        "User-Agent: marciano Kotlin/1.4"
+    )
     @GET("/api/v1/me")
-    fun getIdentity(@Header("Authorization") authorization: String): Call<Identity>
+    suspend fun getIdentity(@Header("Authorization") authorization: String): Response<Identity>
 }

--- a/src/main/kotlin/data/net/api/IdentityService.kt
+++ b/src/main/kotlin/data/net/api/IdentityService.kt
@@ -1,13 +1,16 @@
 package data.net.api
 
 import data.net.model.Identity
+import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Headers
 
-
+/**
+ * A representation of the endpoints related to the "identity" scope.
+ */
 interface IdentityService {
 
     @Headers(
@@ -15,4 +18,10 @@ interface IdentityService {
     )
     @GET("/api/v1/me")
     suspend fun getIdentity(@Header("Authorization") authorization: String): Response<Identity>
+
+    @Headers(
+        "User-Agent: marciano Kotlin/1.4"
+    )
+    @GET("/api/v1/me/trophies")
+    suspend fun getTrophies(@Header("Authorization") authorization: String): Response<ResponseBody>
 }

--- a/src/main/kotlin/data/net/helper/IdentityHelper.kt
+++ b/src/main/kotlin/data/net/helper/IdentityHelper.kt
@@ -1,0 +1,17 @@
+package data.net.helper
+
+import data.net.ServiceBuilder
+import data.net.api.IdentityService
+import data.net.model.Identity
+import okhttp3.ResponseBody
+import retrofit2.Response
+
+object IdentityHelper {
+
+    private val identity: IdentityService by lazy {
+        ServiceBuilder.buildService(IdentityService::class.java, isUsingOauth = true)
+    }
+
+    suspend fun getIdentity(authorization: String): Response<Identity> = identity.getIdentity(authorization)
+    suspend fun getPreferences(authorization: String): Response<ResponseBody> = identity.getTrophies(authorization)
+}

--- a/src/main/kotlin/data/net/model/Identity.kt
+++ b/src/main/kotlin/data/net/model/Identity.kt
@@ -13,11 +13,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Identity(
     val name: String,
-    /**
-     * When the account was created, in Unix
-     * Epoch seconds.
-     */
-    val created: Long,
     @SerialName("comment_karma")
     val commentKarma: Long,
     @SerialName("link_karma")


### PR DESCRIPTION
To avoid confusion as to which endpoints require which retrofit instances, it would be better to call API helper classes that already have that built in. This way making request to endpoints is even more streamlined and safe.

Closes #41 