### PR TITLE
Make token IO operations suspendable

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -8,7 +8,6 @@ fun main() = runBlocking {
     checkAccessTokenExpiration(1800)
 
 
-    codeFlowAuthorization()
 
     // ==============================================
     // GETTING TROPHIES TEST

--- a/src/main/kotlin/authorization/AccessTokenExpirationWatchdog.kt
+++ b/src/main/kotlin/authorization/AccessTokenExpirationWatchdog.kt
@@ -1,10 +1,11 @@
 package authorization
 
+import file.loadToken
 import kotlinx.coroutines.delay
 
 suspend fun checkAccessTokenExpiration(expirationThreshold: Int) {
     println("Checking access token for expiration.")
-    val accessToken = getSavedToken()
+    val accessToken = loadToken()
     if (accessToken.getSecondsTillExpiration() <= expirationThreshold) {
         println("Token under threshold! Refreshing token.")
         refreshAccessToken()

--- a/src/main/kotlin/authorization/AccessTokenManager.kt
+++ b/src/main/kotlin/authorization/AccessTokenManager.kt
@@ -86,7 +86,7 @@ private suspend fun requestAccessToken(httpBasicAuth: String, parameters: Reques
 
 suspend fun refreshAccessToken() {
     println("Refreshing access token")
-    val refreshToken = getSavedToken().refreshToken
+    val refreshToken = loadToken().refreshToken
     checkNotNull(refreshToken) { "No refresh token found" }
 
     val httpBasicAuth = getHttpBasicAuth()
@@ -96,12 +96,4 @@ suspend fun refreshAccessToken() {
     val accessToken = requestAccessToken(httpBasicAuth, parameters)
     checkNotNull(accessToken)
     saveToken(accessToken)
-}
-
-/**
- * Gets the current refresh token from a file on disk.
- * @return The refresh token if it exists, null otherwise.
- */
-fun getSavedToken(): AccessToken {
-    return loadToken()
 }

--- a/src/main/kotlin/file/FileTokenManager.kt
+++ b/src/main/kotlin/file/FileTokenManager.kt
@@ -1,5 +1,7 @@
 package file
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import net.configuredJson
 import net.model.AccessToken
 import kotlinx.serialization.decodeFromString
@@ -8,17 +10,17 @@ import java.io.File
 
 private const val ACCESS_TOKEN_FILEPATH = "access_token.txt"
 
-fun loadToken(): AccessToken {
+suspend fun loadToken(): AccessToken = withContext(Dispatchers.IO) {
     val refreshTokenFile = File(ACCESS_TOKEN_FILEPATH)
     require(refreshTokenFile.exists()) { "No refresh tokens have been saved to a file yet." }
 
     println("Reading refresh token from file.")
     val fileText = File(ACCESS_TOKEN_FILEPATH).readText()
 
-    return configuredJson.decodeFromString(fileText)
+    return@withContext configuredJson.decodeFromString(fileText)
 }
 
-fun saveToken(accessToken: AccessToken) {
+suspend fun saveToken(accessToken: AccessToken) = withContext(Dispatchers.IO) {
     val refreshTokenFile = File(ACCESS_TOKEN_FILEPATH)
     if (refreshTokenFile.exists()) require(refreshTokenFile.canWrite())
 


### PR DESCRIPTION
Functions such as `loadToken()` and `saveToken()` make IO operations that should happen in the IO dispatcher.

Closes #52 